### PR TITLE
software horizontal smooth scrolling helper

### DIFF
--- a/src/SSD1306Ascii.cpp
+++ b/src/SSD1306Ascii.cpp
@@ -264,21 +264,32 @@ size_t SSD1306Ascii::write(uint8_t ch) {
   for (uint8_t r = 0; r < nr; r++) {
     for (uint8_t m = 0; m < m_magFactor; m++) {
       if (r || m) setCursor(scol, m_row + 1);
-      for (uint8_t c = 0; c < w; c++) {
-        uint8_t b = readFontByte(base + c + r*w);
-        if (thieleShift && (r + 1) == nr) {
-          b >>= thieleShift;
+      for (uint8_t c = 0; c < w; c++)
+#if INCLUDE_SCROLLING
+        if (m_xshift > 0)
+          --m_xshift;
+        else
+#endif
+        {
+          uint8_t b = readFontByte(base + c + r*w);
+          if (thieleShift && (r + 1) == nr) {
+            b >>= thieleShift;
+          }
+          if (m_magFactor == 2) {
+             b = m ?  b >> 4 : b & 0XF;
+             b = readFontByte(scaledNibble + b);
+             ssd1306WriteRamBuf(b);
+          }
+          ssd1306WriteRamBuf(b);
         }
-        if (m_magFactor == 2) {
-           b = m ?  b >> 4 : b & 0XF;
-           b = readFontByte(scaledNibble + b);
-           ssd1306WriteRamBuf(b);
+        for (uint8_t i = 0; i < s; i++) {
+#if INCLUDE_SCROLLING
+          if (m_xshift > 0)
+            --m_xshift;
+          else
+#endif
+            ssd1306WriteRamBuf(0);
         }
-        ssd1306WriteRamBuf(b);
-      }
-      for (uint8_t i = 0; i < s; i++) {
-        ssd1306WriteRamBuf(0);
-      }
     }
   }
   setRow(srow);

--- a/src/SSD1306Ascii.h
+++ b/src/SSD1306Ascii.h
@@ -161,6 +161,10 @@ class SSD1306Ascii : public Print {
    * @return the display startline.
    */
   uint8_t startLine() const {return m_startLine;}
+  /**
+   * @brief software shift next write(s) by swallowing columns
+   */
+  void xShift (uint8_t shift) { m_xshift = shift; }
 #endif  // INCLUDE_SCROLLING
   //----------------------------------------------------------------------------
   /**
@@ -391,6 +395,7 @@ class SSD1306Ascii : public Print {
   uint8_t m_startLine;      // Top line of display
   uint8_t m_pageOffset;     // Top page of RAM window.
   uint8_t m_scrollMode = INITIAL_SCROLL_MODE;  // Scroll mode for newline.
+  uint8_t m_xshift = 0;     // x pixel software shift
 #endif  // INCLUDE_SCROLLING
   const uint8_t* m_font = nullptr;  // Current font.
   uint8_t m_invertMask = 0;  // font invert mask


### PR DESCRIPTION
This is a proof of concept.
I'm using this helper to allow smooth scrolling for a specific horizontal line by calling `oled.xshift(n)` prior calling `oled.print("my long string")` every 50ms, with `n` varying.

(formula to calculate maximum `n` value depending on string and font is not yet exact)