### PR TITLE
fonts: Fix typos in header guards

### DIFF
--- a/src/fonts/CalBlk36.h
+++ b/src/fonts/CalBlk36.h
@@ -57,7 +57,7 @@
  */
 
 #ifndef CalBlk36_H
-#define CalBlk32_H
+#define CalBlk36_H
 
 #define CalBlk36_WIDTH 28
 #define CalBlk36_HEIGHT 36

--- a/src/fonts/SystemFont5x7.h
+++ b/src/fonts/SystemFont5x7.h
@@ -1,4 +1,4 @@
-#ifndef SYSTEM5FONTx7_H
+#ifndef SYSTEMFONT5x7_H
 #define SYSTEMFONT5x7_H
 
 /*


### PR DESCRIPTION
These typos were caught by compiling this project using clang++ 14.0.0-1ubuntu1 on Ubuntu 22.04 with `-Wextra -Wall` flags. Also, thanks for the recent change to MIT License.
