### PR TITLE
Allow space character (ascii 32) in all fonts

### DIFF
--- a/src/SSD1306Ascii.h
+++ b/src/SSD1306Ascii.h
@@ -193,6 +193,18 @@ class SSD1306Ascii : public Print {
 #endif  // INCLUDE_SCROLLING
   //----------------------------------------------------------------------------
   /**
+   * @brief Always allow the space character (0x20) to be valid even on fonts
+   * without an explicit encoding for the space character. The default is false.
+   * This will be most useful for fixed-sized fonts when: (1) Printing numbers
+   * which are right-justified with leading spaces instead of leading zeros; (2)
+   * Blinking letters by overwriting them with the space character.
+   *
+   * @param[in] alwaysAllowSpace set true to allow space character
+   */
+  void alwaysAllowSpace(bool alwaysAllowSpace) {
+    m_alwaysAllowSpace = alwaysAllowSpace;
+  }
+  /**
    * @brief Determine the spacing of a character. Spacing is width + space.
    *
    * @param[in] c Character code.
@@ -477,5 +489,6 @@ class SSD1306Ascii : public Print {
   const uint8_t* m_font = nullptr;  // Current font.
   uint8_t m_invertMask = 0;  // font invert mask
   uint8_t m_magFactor = 1;   // Magnification factor.
+  bool m_alwaysAllowSpace = false;  // Always write the space char for all fonts
 };
 #endif  // SSD1306Ascii_h


### PR DESCRIPTION
If a font does not have an encoding for the space character, it will normally be skipped and nothing is printed. Calling `alwaysAllowSpace(true)` causes the space character to be printed for all fonts. The width of the space character will be the FONT_WIDTH of the font.

**Additional PR Notes**

I wonder if you would consider merging this feature. I've been carrying this patch in my fork for a few years. With the recent change to MIT License, I'd like to upstream it to eliminate the `git rebase` conflicts that I sometimes have to deal with.

This will be most useful for fixed-sized fonts when: (1) Printing numbers which are right-justified with leading spaces instead of leading zeros; (2) Blinking letters by overwriting them with the space character.