### PR TITLE
Add support for SSD1306 64x32 0.49 inch oled display

### DIFF
--- a/src/SSD1306init.h
+++ b/src/SSD1306init.h
@@ -269,5 +269,34 @@ static const DevType MEM_TYPE SH1106_128x64 =  {
   64,
   2    // SH1106 is a 132x64 controller.  Use middle 128 columns.
 };
+//------------------------------------------------------------------------------
+// this section is based on 64x48 Micro OLED display (by r7)
+/** Initialization commands for a 64x32 SSD1306 0.49 inch oled display. */
+static const uint8_t MEM_TYPE MicroOLED64x32init[] = {
+    // Init sequence for 64x32 Micro OLED module
+    SSD1306_DISPLAYOFF,
+    SSD1306_SETDISPLAYCLOCKDIV, 0x80,  // the suggested ratio 0x80
+    SSD1306_SETMULTIPLEX, 0x1F,        // (DISPLAYHEIGHT - 1)
+    SSD1306_SETDISPLAYOFFSET, 0x0,     // no offset
+    SSD1306_SETSTARTLINE,              // line #0
+    SSD1306_CHARGEPUMP, 0x14,          // internal vcc
+    SSD1306_NORMALDISPLAY,
+    SSD1306_DISPLAYALLON_RESUME,
+    SSD1306_SEGREMAP | 0x1,            // column 127 mapped to SEG0
+    SSD1306_COMSCANDEC,                // column scan direction reversed
+    SSD1306_SETCOMPINS, 0x12,          // 0x12 if height > 32 else 0x02
+    SSD1306_SETCONTRAST, 0x7F,         // contrast level 127
+    SSD1306_SETPRECHARGE, 0xF1,        // pre-charge period (1, 15)
+    SSD1306_SETVCOMDETECT, 0x40,       // vcomh regulator level
+    SSD1306_DISPLAYON
+};
+/** Initialize a 64x32 Micro OLED display. */
+static const DevType MEM_TYPE MicroOLED64x32 = {
+  MicroOLED64x32init,
+  sizeof(MicroOLED64x32init),
+  64,
+  32,
+  32 // Use middle 64 columns. (128 - 64) / 2
+};
 // clang-format on
 #endif  // SSD1306init_h


### PR DESCRIPTION
Add support for SSD1306 64x32 0.49 inch oled display .

Tested with 
* I2C OLED SSD1306 64x32 0.49 inch
* RP2040 I2C
* ESP32-S2 I2C

How to use it:
```
// I2C OLED SSD1306 64x32 0.49 inch
#define OLED_I2C_ADDRESS 0x3C
oled.begin(&MicroOLED64x32, OLED_I2C_ADDRESS);
````

![Cimg4219](https://user-images.githubusercontent.com/16265606/232266452-61c6127c-bbac-4d48-a145-3b11179a8b37.jpg)  
![Cimg4220](https://user-images.githubusercontent.com/16265606/232266453-65205bd1-4ab6-4b37-9cf9-a75de3224782.jpg)  
![Cimg4221](https://user-images.githubusercontent.com/16265606/232266603-97de014e-99dc-40d8-994b-9604223f2f39.jpg)  
