### PR TITLE
Add support SoftWire for non AVR

### DIFF
--- a/examples/TestSSD1306AsciiSoftWire/TestSSD1306AsciiSoftWire.ino
+++ b/examples/TestSSD1306AsciiSoftWire/TestSSD1306AsciiSoftWire.ino
@@ -1,0 +1,59 @@
+// SSD1306AsciiSoftWire.h Sample Program
+// https://youtu.be/JHlt9EG22BI
+
+// https://github.com/stevemarple/SoftWire
+#include <SoftWire.h>
+
+#include <SSD1306Ascii.h>
+#include <SSD1306AsciiSoftWire.h>
+
+#define OLED_I2C_ADDRESS 0x3C
+
+// ESP32-C3 Tested OK
+// #define OLED_SDA 0
+// #define OLED_SCL 1
+
+// ESP32-S2 Tested OK
+#define OLED_SDA 7
+#define OLED_SCL 9
+
+// RP2040 Tested NG SoftWire signal contain Pulse
+// #define OLED_SDA 20
+// #define OLED_SCL 21
+
+SoftWire WireOled = SoftWire(OLED_SDA, OLED_SCL);
+SSD1306AsciiSoftWire oled = SSD1306AsciiSoftWire(&WireOled);
+
+void setup() {
+  // put your setup code here, to run once:
+  static uint8_t txBuffer[32];
+  WireOled.setTxBuffer(txBuffer, 32);
+  // WireOled.setClock(10000);
+  WireOled.begin();
+
+  oled.begin(&MicroOLED64x32, OLED_I2C_ADDRESS);
+  // oled.begin(&Adafruit128x32, OLED_I2C_ADDRESS);
+  oled.setFont(System5x7);
+}
+ 
+void loop() {
+  // put your main code here, to run repeatedly:
+  static int invert = 0;
+
+  invert = 1 - invert;
+
+  oled.setInvertMode(invert);
+  oled.setCursor(0, 0);
+  oled.set1X();
+  oled.print("SoftWire");
+
+  oled.setCursor(0, 1);
+  oled.set2X();
+  oled.print("SoftWire");
+
+  oled.setInvertMode(!invert);
+  oled.setCursor(0, 3);
+  oled.set1X();
+  oled.print("SoftWire");
+}
+

--- a/src/SSD1306AsciiSoftWire.h
+++ b/src/SSD1306AsciiSoftWire.h
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2011-2023 Bill Greiman
+ * This file is part of the Arduino SSD1306Ascii Library
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file SSD1306AsciiSoftWire.h
+ * @brief Class for I2C displays using SoftWire.
+ */
+#ifndef SSD1306AsciiSoftWire_h
+#define SSD1306AsciiSoftWire_h
+#include <SoftWire.h>
+
+#include "SSD1306Ascii.h"
+/**
+ * @class SSD1306AsciiSoftWire
+ * @brief Class for I2C displays using Wire.
+ */
+class SSD1306AsciiSoftWire : public SSD1306Ascii {
+ public:
+  /**
+   * @brief Initialize object on specific I2C bus.
+   *
+   * @param[in] bus The I2C bus to be used.
+   */
+  explicit SSD1306AsciiSoftWire(SoftWire* bus) : m_oledWire(bus) {}
+  /**
+   * @brief Initialize the display controller.
+   *
+   * @param[in] dev A device initialization structure.
+   * @param[in] i2cAddr The I2C address of the display controller.
+   */
+  void begin(const DevType* dev, uint8_t i2cAddr) {
+#if OPTIMIZE_I2C
+    m_nData = 0;
+#endif  // OPTIMIZE_I2C
+    m_i2cAddr = i2cAddr;
+    init(dev);
+  }
+  /**
+   * @brief Initialize the display controller.
+   *
+   * @param[in] dev A device initialization structure.
+   * @param[in] i2cAddr The I2C address of the display controller.
+   * @param[in] rst The display controller reset pin.
+   */
+  void begin(const DevType* dev, uint8_t i2cAddr, uint8_t rst) {
+    oledReset(rst);
+    begin(dev, i2cAddr);
+  }
+  /**
+   * @brief Set the I2C clock rate to 400 kHz.
+   * Deprecated use Wire.setClock(400000L)
+   */
+  void set400kHz() __attribute__((deprecated("use Wire.setClock(400000L)"))) {
+    m_oledWire->setClock(400000L);
+  }
+
+ protected:
+  void writeDisplay(uint8_t b, uint8_t mode) {
+#if OPTIMIZE_I2C
+    if (m_nData > 16 || (m_nData && mode == SSD1306_MODE_CMD)) {
+      m_oledWire->endTransmission();
+      m_nData = 0;
+    }
+    if (m_nData == 0) {
+      m_oledWire->beginTransmission(m_i2cAddr);
+      m_oledWire->write(mode == SSD1306_MODE_CMD ? 0X00 : 0X40);
+    }
+    m_oledWire->write(b);
+    if (mode == SSD1306_MODE_RAM_BUF) {
+      m_nData++;
+    } else {
+      m_oledWire->endTransmission();
+      m_nData = 0;
+    }
+#else   // OPTIMIZE_I2C
+    m_oledWire->beginTransmission(m_i2cAddr);
+    m_oledWire->write(mode == SSD1306_MODE_CMD ? 0X00 : 0X40);
+    m_oledWire->write(b);
+    m_oledWire->endTransmission();
+#endif  // OPTIMIZE_I2C
+  }
+
+ protected:
+  SoftWire* m_oledWire;
+  uint8_t m_i2cAddr;
+#if OPTIMIZE_I2C
+  uint8_t m_nData;
+#endif  // OPTIMIZE_I2C
+};
+#endif  // SSD1306AsciiSoftWire_h


### PR DESCRIPTION
Add support SoftWire for non AVR

ESP32-C3 has only one I2C .
I need more I2C .
So I add this .

Tested with
* I2C OLED SSD1306 64x32 0.49 inch
* ESP32-C3 Tested OK
* ESP32-S2 Tested OK
* RP2040 Tested NG SoftWire signal contain Pulse

Demo movie
[<img src="https://img.youtube.com/vi/JHlt9EG22BI/maxresdefault.jpg" title="ESP32 SoftWire I2C OLED SSD1306 demo" width="320" height="180">  YouTube https://youtu.be/JHlt9EG22BI](https://youtu.be/JHlt9EG22BI)  
